### PR TITLE
feat: redirect logged-in users from homepage to /dashboard

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,18 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect();
+  }
+
+  const { userId } = await auth();
+  if (userId && req.nextUrl.pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", req.url));
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Redirects authenticated users from `/` to `/dashboard` via Clerk middleware. Also adds route protection for all `/dashboard` routes.

Closes #2

Generated with [Claude Code](https://claude.ai/code)